### PR TITLE
Fix parsing of CSR in utils

### DIFF
--- a/src/main/java/com/czertainly/utils/service/impl/Pkcs10RequestUtilsServiceImpl.java
+++ b/src/main/java/com/czertainly/utils/service/impl/Pkcs10RequestUtilsServiceImpl.java
@@ -18,8 +18,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 @Service
 public class Pkcs10RequestUtilsServiceImpl implements RequestUtilsService {
@@ -31,7 +33,13 @@ public class Pkcs10RequestUtilsServiceImpl implements RequestUtilsService {
         parseRequestResponseDto.setType(RequestType.PKCS10);
         JcaPKCS10CertificationRequest jcaPKCS10CertificationRequest;
         try {
-            jcaPKCS10CertificationRequest = new JcaPKCS10CertificationRequest(parseRequestRequestDto.getRequest());
+            jcaPKCS10CertificationRequest = new JcaPKCS10CertificationRequest(
+                    Base64.getDecoder().decode(
+                            Pkcs10Tools.normalize(
+                                    parseRequestRequestDto.getRequest()
+                            ).getBytes(StandardCharsets.UTF_8)
+                    )
+            );
         } catch (IOException e) {
             throw new RequestUtilsException(HttpStatus.BAD_REQUEST, RequestUtilsError.REQUEST_PARSING_ERROR, e);
         }

--- a/src/main/java/com/czertainly/utils/tools/Pkcs10Tools.java
+++ b/src/main/java/com/czertainly/utils/tools/Pkcs10Tools.java
@@ -53,4 +53,15 @@ public class Pkcs10Tools {
         }
         return attributes;
     }
+
+    public static String normalize(String csr) {
+        return csr
+                .replaceAll("-----BEGIN CERTIFICATE REQUEST-----", "")
+                .replaceAll(System.lineSeparator(), "")
+                .replaceAll("-----END CERTIFICATE REQUEST-----", "");
+    }
+
+    public static String normalize(byte[] csr) {
+        return normalize(new String(csr));
+    }
 }


### PR DESCRIPTION
This PR contains the changes for the following.

1. Add CSR normalization to the pkcs10Util
2. Decode the CSR using Base64 decoder before parsing using jcapkcs10request from bouncy castle